### PR TITLE
Fix API key configuration issue by storing input values in database

### DIFF
--- a/mcpm/commands/configure.py
+++ b/mcpm/commands/configure.py
@@ -7,7 +7,7 @@ import questionary
 from pathlib import Path
 
 from mcpm.config.manager import get_target_config_path, update_mcp_config_file_for_configure, remove_server_from_mcp_config
-from mcpm.database.local_db import init_local_db, get_all_installed_package_details
+from mcpm.database.local_db import init_local_db, get_all_installed_package_details, get_package_input_values
 from mcpm.utils.ui_helpers import _configure_specific_package
 
 def configure_command_func(package_name=None, target_ide=None, action=None, non_interactive=False):
@@ -153,10 +153,13 @@ def _process_configuration(package_name, package_path, target_ide, action):
     # Get the install_name from metadata (for config key)
     install_name = package_metadata.get("install_name", package_name)
     
+    # Get stored input values for this package
+    input_values = get_package_input_values(install_name)
+    
     # Process the action
     if action == "add":
         # Update the configuration
-        if update_mcp_config_file_for_configure(config_path, install_name, ide_config, pkg_install_path):
+        if update_mcp_config_file_for_configure(config_path, install_name, ide_config, pkg_install_path, input_values):
             click.echo(f"Successfully configured {package_name} for {target_ide}.")
         else:
             click.echo(f"Failed to configure {package_name} for {target_ide}.", err=True)

--- a/mcpm/database/local_db.py
+++ b/mcpm/database/local_db.py
@@ -3,6 +3,7 @@ Local SQLite database operations for tracking installed packages.
 """
 import sqlite3
 import click
+import json
 from pathlib import Path
 
 from mcpm.config.constants import LOCAL_DB_DIR, LOCAL_DB_PATH
@@ -29,6 +30,18 @@ def init_local_db():
                     version TEXT NOT NULL,
                     install_path TEXT NOT NULL,
                     installed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            
+            # Create table for storing package input values
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS package_input_values (
+                    package_name TEXT NOT NULL,
+                    input_name TEXT NOT NULL,
+                    input_value TEXT NOT NULL,
+                    is_secret INTEGER DEFAULT 0,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (package_name, input_name)
                 )
             ''')
             conn.commit()
@@ -75,7 +88,12 @@ def remove_package_from_local_db(install_name):
     if conn:
         try:
             cursor = conn.cursor()
+            # Remove from installed_packages table
             cursor.execute("DELETE FROM installed_packages WHERE name = ?", (install_name,))
+            
+            # Also remove any stored input values for this package
+            cursor.execute("DELETE FROM package_input_values WHERE package_name = ?", (install_name,))
+            
             conn.commit()
             if cursor.rowcount > 0:
                 click.echo(f"Package {install_name} marked as uninstalled locally.")
@@ -114,5 +132,73 @@ def get_all_installed_package_details():
     except sqlite3.Error as e:
         click.echo(f"Error fetching installed packages: {e}", err=True)
         return []
+    finally:
+        conn.close()
+
+def store_package_input_values(package_name, input_values):
+    """Stores input values for a package in the local database.
+    
+    Args:
+        package_name: The name of the package (install_name).
+        input_values: Dictionary of input values to store.
+    """
+    if not input_values:
+        return
+        
+    conn = _get_local_db_connection()
+    if not conn:
+        return
+        
+    try:
+        cursor = conn.cursor()
+        for input_name, input_value in input_values.items():
+            # Check if this is a secret value
+            is_secret = False
+            
+            # Store the input value
+            cursor.execute('''
+                INSERT OR REPLACE INTO package_input_values 
+                (package_name, input_name, input_value, is_secret, created_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ''', (package_name, input_name, input_value, 1 if is_secret else 0))
+        
+        conn.commit()
+        click.echo(f"Stored input values for package {package_name}.")
+    except sqlite3.Error as e:
+        click.echo(f"Error storing input values for package {package_name}: {e}", err=True)
+    finally:
+        conn.close()
+
+def get_package_input_values(package_name):
+    """Retrieves stored input values for a package from the local database.
+    
+    Args:
+        package_name: The name of the package (install_name).
+        
+    Returns:
+        A dictionary of input values keyed by input name.
+    """
+    conn = _get_local_db_connection()
+    if not conn:
+        return {}
+        
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT input_name, input_value, is_secret FROM package_input_values WHERE package_name = ?", 
+            (package_name,)
+        )
+        rows = cursor.fetchall()
+        
+        # Convert rows to a dictionary
+        input_values = {}
+        for row in rows:
+            input_name, input_value, is_secret = row
+            input_values[input_name] = input_value
+            
+        return input_values
+    except sqlite3.Error as e:
+        click.echo(f"Error retrieving input values for package {package_name}: {e}", err=True)
+        return {}
     finally:
         conn.close()

--- a/mcpm/utils/package_helpers.py
+++ b/mcpm/utils/package_helpers.py
@@ -10,7 +10,7 @@ import subprocess
 from pathlib import Path
 
 from mcpm.config.constants import INSTALL_DIR
-from mcpm.database.local_db import add_package_to_local_db, remove_package_from_local_db
+from mcpm.database.local_db import add_package_to_local_db, remove_package_from_local_db, store_package_input_values
 
 def get_installed_packages():
     """Lists locally installed packages."""
@@ -86,6 +86,9 @@ def install_package_from_zip(zip_path, package_name):
                 # Extract package metadata for local DB
                 install_name = metadata.get("install_name", package_name)
                 version = metadata.get("version", "0.0.1")
+                
+                # Store input values in the database for later use
+                store_package_input_values(install_name, install_inputs_values)
                 
                 # Add to local database
                 add_package_to_local_db(install_name, version, str(target_install_path))

--- a/mcpm/utils/ui_helpers.py
+++ b/mcpm/utils/ui_helpers.py
@@ -305,10 +305,14 @@ def _configure_specific_package(package_name, package_path):
     # Get the install_name from metadata (for config key)
     install_name = package_metadata.get("install_name", package_name)
     
+    # Get stored input values for this package
+    from mcpm.database.local_db import get_package_input_values
+    input_values = get_package_input_values(install_name)
+    
     # Process the action
     if action == "add":
         # Update the configuration
-        if update_mcp_config_file_for_configure(config_path, install_name, ide_config, pkg_install_path):
+        if update_mcp_config_file_for_configure(config_path, install_name, ide_config, pkg_install_path, input_values):
             click.echo(f"Successfully configured {package_name} for {target_ide}.")
         else:
             click.echo(f"Failed to configure {package_name} for {target_ide}.", err=True)


### PR DESCRIPTION
This commit addresses a bug where API keys and other input values collected during package installation were not being used during the later configuration step.

Changes include:
- Added a new database table 'package_input_values' to store input values
- Added functions to store and retrieve these values
- Modified the installation process to save input values to the database
- Updated the configuration process to retrieve and use these stored values
- Implemented variable substitution in configuration snippets